### PR TITLE
Fix header to show Course Materials Assistant with proper styling

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -32,6 +32,7 @@
         <header>
             <h1>Course Materials Assistant</h1>
             <p class="subtitle">Ask questions about courses, instructors, and content</p>
+            <hr class="header-divider">
         </header>
 
         <div class="main-content">

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -70,9 +70,12 @@ body {
     padding: 0;
 }
 
-/* Header - Hidden */
+/* Header */
 header {
-    display: none;
+    padding: 2rem;
+    text-align: center;
+    border-bottom: 1px solid var(--border-color);
+    background: var(--surface);
 }
 
 header h1 {
@@ -89,6 +92,14 @@ header h1 {
     font-size: 0.95rem;
     color: var(--text-secondary);
     margin-top: 0.5rem;
+}
+
+.header-divider {
+    border: none;
+    border-top: 1px solid var(--border-color);
+    margin: 1.5rem auto 0;
+    width: 100%;
+    max-width: 600px;
 }
 
 /* Main Content Area with Sidebar */
@@ -759,11 +770,16 @@ details[open] .suggested-header::before {
     }
     
     header {
-        padding: 1rem;
+        padding: 1.5rem 1rem;
     }
     
     header h1 {
         font-size: 1.5rem;
+    }
+    
+    .header-divider {
+        margin: 1rem auto 0;
+        max-width: 90%;
     }
     
     .chat-messages {


### PR DESCRIPTION
This PR fixes the application header to use the newer version as requested in issue #3.

## Changes
- Make header visible (was previously hidden with `display: none`)
- Add horizontal rule below subheader as requested
- Update CSS styling for proper header display with padding and background
- Add responsive mobile styling for the header

The header now properly displays:
1. "Course Materials Assistant" as the main title
2. "Ask questions about courses, instructors, and content" as the subheader
3. A horizontal rule below the subheader

Fixes #3

Generated with [Claude Code](https://claude.ai/code)